### PR TITLE
paperspace.com no longer resolves, use www.paperspce.com instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Using Shell (macOS, Linux, and Windows using WSL):
 
 ```sh
-curl -fsSL https://paperspace.com/install.sh | sh
+curl -fsSL https://www.paperspace.com/install.sh | sh
 ```
 
 ## Usage


### PR DESCRIPTION
As of last night paperspace.com doesn't resolve and is breaking our CI/CD pipeline as it uses paperspace.com to resolve. 

Changing README to reflect new domain