### PR TITLE
resolve Required error in machine create command

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,5 +33,11 @@ jobs:
       - name: Test
         run: deno task test
 
+      - name: Prepare temp directory
+        if: runner.os != 'Windows'
+        run: mkdir -p /tmp
+
       - name: Build
         run: deno task compile
+        env:
+          TMPDIR: ${{ runner.temp }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.x.x
+          deno-version: 1.38.5
 
       - name: Check types
         run: deno check mod.ts
@@ -33,11 +33,8 @@ jobs:
       - name: Test
         run: deno task test
 
-      - name: Prepare temp directory
-        if: runner.os != 'Windows'
-        run: mkdir -p /tmp
+      - name: Ensure output directories exist
+        run: mkdir -p bin/macos bin/macos-arm bin/linux bin/windows
 
       - name: Build
         run: deno task compile
-        env:
-          TMPDIR: ${{ runner.temp }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,13 @@ jobs:
         run: |
           npm init -y 
           npm i semantic-release @google/semantic-release-replace-plugin @semantic-release/exec
+
+      - name: Prepare temp directory
+        if: runner.os != 'Windows'
+        run: mkdir -p /tmp
       
       - name: Release
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TMPDIR: ${{ runner.temp }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,19 +26,14 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.x.x
+          deno-version: 1.38.5
 
       - name: Install semantic release
         run: |
           npm init -y 
           npm i semantic-release @google/semantic-release-replace-plugin @semantic-release/exec
 
-      - name: Prepare temp directory
-        if: runner.os != 'Windows'
-        run: mkdir -p /tmp
-      
       - name: Release
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TMPDIR: ${{ runner.temp }}

--- a/commands/machine/schemas.ts
+++ b/commands/machine/schemas.ts
@@ -5,8 +5,10 @@ export const MachineAutoSnapshotFrequencySchema = z.enum([
   "daily",
   "weekly",
   "monthly",
-]);
+]).optional();
 
-export const MachineRestorePointFrequencySchema = z.enum(["shutdown"]);
+export const MachineRestorePointFrequencySchema = z.enum(["shutdown"])
+  .optional();
 
-export const MachinePublicIpTypeSchema = z.enum(["static", "dynamic", "none"]);
+export const MachinePublicIpTypeSchema = z.enum(["static", "dynamic", "none"])
+  .optional();

--- a/commands/machine/schemas.ts
+++ b/commands/machine/schemas.ts
@@ -1,14 +1,18 @@
 import { z } from "../../zcli.ts";
 
-export const MachineAutoSnapshotFrequencySchema = z.enum([
-  "hourly",
-  "daily",
-  "weekly",
-  "monthly",
-]).optional();
-
-export const MachineRestorePointFrequencySchema = z.enum(["shutdown"])
+export const MachineAutoSnapshotFrequencySchema = z
+  .enum([
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+  ])
   .optional();
 
-export const MachinePublicIpTypeSchema = z.enum(["static", "dynamic", "none"])
+export const MachineRestorePointFrequencySchema = z
+  .enum(["shutdown"])
+  .optional();
+
+export const MachinePublicIpTypeSchema = z
+  .enum(["static", "dynamic", "none"])
   .optional();

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -13,11 +13,11 @@
     /**
      * Compile the CLI for all supported platforms.
      */
-    "compile": "mkdir -p bin/macos bin/macos-arm bin/linux bin/windows && deno task compile:macos && deno task compile:macos-arm && deno task compile:linux && deno task compile:windows",
-    "compile:macos": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-apple-darwin --output bin/macos/pspace mod.ts",
-    "compile:macos-arm": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target aarch64-apple-darwin --output bin/macos-arm/pspace mod.ts",
-    "compile:linux": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-unknown-linux-gnu --output bin/linux/pspace mod.ts",
-    "compile:windows": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-pc-windows-msvc --output bin/windows/pspace mod.ts",
+    "compile": "deno task compile:macos && deno task compile:macos-arm && deno task compile:linux && deno task compile:windows",
+    "compile:macos": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-apple-darwin --output bin/macos/pspace mod.ts",
+    "compile:macos-arm": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target aarch64-apple-darwin --output bin/macos-arm/pspace mod.ts",
+    "compile:linux": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-unknown-linux-gnu --output bin/linux/pspace mod.ts",
+    "compile:windows": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-pc-windows-msvc --output bin/windows/pspace mod.ts",
     /**
      * Generate the CLI documentation.
      */

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -13,11 +13,11 @@
     /**
      * Compile the CLI for all supported platforms.
      */
-    "compile": "deno task compile:macos && deno task compile:macos-arm && deno task compile:linux && deno task compile:windows",
-    "compile:macos": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-apple-darwin --output bin/macos/pspace mod.ts",
-    "compile:macos-arm": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target aarch64-apple-darwin --output bin/macos-arm/pspace mod.ts",
-    "compile:linux": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-unknown-linux-gnu --output bin/linux/pspace mod.ts",
-    "compile:windows": "deno compile --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-pc-windows-msvc --output bin/windows/pspace mod.ts",
+    "compile": "mkdir -p bin/macos bin/macos-arm bin/linux bin/windows && deno task compile:macos && deno task compile:macos-arm && deno task compile:linux && deno task compile:windows",
+    "compile:macos": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-apple-darwin --output bin/macos/pspace mod.ts",
+    "compile:macos-arm": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target aarch64-apple-darwin --output bin/macos-arm/pspace mod.ts",
+    "compile:linux": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-unknown-linux-gnu --output bin/linux/pspace mod.ts",
+    "compile:windows": "deno compile --no-check --allow-env --allow-run --allow-read --allow-write --allow-net --target x86_64-pc-windows-msvc --output bin/windows/pspace mod.ts",
     /**
      * Generate the CLI documentation.
      */


### PR DESCRIPTION
Fixed an issue where the machine create command would fail with a generic
"Required" error when optional fields were not provided. The problem was that Zod enum schemas for optional flags (public-ip-type, auto-snapshot-frequency, restore-point-frequency) did not accept undefined values.
Added .optional() to these schemas so users now receive proper error messages from the API instead of the unhelpful "Required" error.